### PR TITLE
Basic types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,7 @@ dependencies = [
  "indexmap",
  "lazy_static",
  "nohash-hasher",
+ "ordered-float",
  "peg",
  "regex",
 ]
@@ -61,6 +62,24 @@ name = "nohash-hasher"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
+
+[[package]]
+name = "num-traits"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "ordered-float"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7940cf2ca942593318d07fcf2596cdca60a85c9e7fab408a5e21a4f9dcd40d87"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "peg"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,7 +27,14 @@ dependencies = [
  "ordered-float",
  "peg",
  "regex",
+ "rstest",
 ]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "hashbrown"
@@ -142,6 +149,45 @@ name = "regex-syntax"
 version = "0.6.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+
+[[package]]
+name = "rstest"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d912f35156a3f99a66ee3e11ac2e0b3f34ac85a07e05263d05a7e2c8810d616f"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d65bd28f48be7196d222d95b9243287f48d27aca604e08497513019ff0502cc4"
+
+[[package]]
+name = "syn"
+version = "1.0.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d010a1623fbd906d51d650a9916aaefc05ffa0e4053ff7fe601167f3e715d194"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,8 @@ lazy_static = "1.4.0"
 regex = "1"
 nohash-hasher = "0.2.0"
 ordered-float = "2.0"
+
+[dev-dependencies]
 rstest = "0.12.0"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ lazy_static = "1.4.0"
 regex = "1"
 nohash-hasher = "0.2.0"
 ordered-float = "2.0"
+rstest = "0.12.0"
 
 [features]
 default = ["print-chunk"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ indexmap = "1.8.0"
 lazy_static = "1.4.0"
 regex = "1"
 nohash-hasher = "0.2.0"
+ordered-float = "2.0"
 
 [features]
 default = ["print-chunk"]

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The interpreter supports (somewhat working) REPL mode, but is mainly intended fo
 
 Language provides a few basic building blocks:
 
-* integer numbers like `42`
+* few basic types like integers `42`, floats `0.5`, booleans `true` and `false`, special value `Nothing`
 * `"strings in double quotes"`
 * basic operators like `+` and `==`
 * logic short-circuting operators `and`, `or`

--- a/examples/builtins.txt
+++ b/examples/builtins.txt
@@ -5,6 +5,9 @@ assert n==2
 
 print(int)
 
+print(true)
+print(false)
+
 var negative_number = 0-5
 
 #calling methods on builtin types

--- a/examples/conditions.txt
+++ b/examples/conditions.txt
@@ -26,4 +26,4 @@ def G(x) =
 
 assert G(1)==1
 assert G(2)==2
-assert G(3)==0
+assert G(3)==Nothing

--- a/examples/operators.txt
+++ b/examples/operators.txt
@@ -36,4 +36,10 @@ assert 1<2 or should_not_execute()
 assert not (1==2 and should_not_execute())
 
 #float-point numbers
-print(0.5+1)
+assert 1.0 == 1.0
+
+#ints are converted to floats when needed for comparison
+assert 1 < 1.5
+#and also converted whe performing operations with floats
+assert 5/2 == 2
+assert 5/2.0 == 2.5

--- a/examples/operators.txt
+++ b/examples/operators.txt
@@ -34,3 +34,6 @@ assert 1<2 or should_not_execute()
 
 #and shortcircuited
 assert not (1==2 and should_not_execute())
+
+#float-point numbers
+print(0.5+1)

--- a/examples/operators.txt
+++ b/examples/operators.txt
@@ -43,3 +43,12 @@ assert 1 < 1.5
 #and also converted whe performing operations with floats
 assert 5/2 == 2
 assert 5/2.0 == 2.5
+
+#bool literals
+assert true
+assert not false
+
+#nothing that indicates absence of value
+def do_nothing() =
+    pass
+assert do_nothing() == Nothing

--- a/src/compile/checks/constant_folding.rs
+++ b/src/compile/checks/constant_folding.rs
@@ -34,6 +34,7 @@ impl Rewriter<String> for Folder {
 
                 enum FoldResult {
                     Ok(i64),
+                    OkBool(bool),
                     Warning(String),
                     Error(String),
                 }
@@ -59,7 +60,8 @@ impl Rewriter<String> for Folder {
 
                     TokenKind::Minus => FoldResult::Ok(na - nb),
 
-                    TokenKind::CompareEquals => FoldResult::Ok(if na == nb { 1 } else { 0 }),
+                    TokenKind::CompareEquals => FoldResult::OkBool(na==nb),
+                    TokenKind::CompareNotEquals => FoldResult::OkBool(na!=nb),
 
                     TokenKind::Power => match na.checked_pow(nb as u64 as u32) {
                         Some(value) => FoldResult::Ok(value),
@@ -73,6 +75,10 @@ impl Rewriter<String> for Folder {
                     FoldResult::Ok(number) => Expr::Number(Token {
                         position: a.position,
                         kind: TokenKind::Number(number),
+                    }),
+                    FoldResult::OkBool(b) => Expr::Bool(Token {
+                        position: a.position,
+                        kind: if b { TokenKind::True } else { TokenKind::False },
                     }),
                     FoldResult::Warning(w) => {
                         eprintln!("{}", w);

--- a/src/compile/checks/tree_rewriter.rs
+++ b/src/compile/checks/tree_rewriter.rs
@@ -115,6 +115,7 @@ pub(super) trait Rewriter<E> {
 
     fn visit_expr(&mut self, expr: Expr) -> Result<Expr, E> {
         match expr {
+            Expr::Bool(b) => self.visit_bool_expr(b),
             Expr::Number(n) => self.visit_number_expr(n),
             Expr::Name(n) => self.visit_variable_expr(n),
             Expr::ConstString(s) => self.visit_string_expr(s),
@@ -133,6 +134,10 @@ pub(super) trait Rewriter<E> {
             Expr::PropertyAccess(target, prop) => self.visit_property_access(target, prop),
             Expr::PropertyTest(target, prop) => self.visit_property_check(target, prop),
         }
+    }
+
+    fn visit_bool_expr(&mut self, token: Token) -> Result<Expr, E> {
+        Ok(Expr::Bool(token))
     }
 
     fn visit_number_expr(&mut self, token: Token) -> Result<Expr, E> {

--- a/src/compile/checks/tree_rewriter.rs
+++ b/src/compile/checks/tree_rewriter.rs
@@ -117,6 +117,7 @@ pub(super) trait Rewriter<E> {
         match expr {
             Expr::Bool(b) => self.visit_bool_expr(b),
             Expr::Number(n) => self.visit_number_expr(n),
+            Expr::FloatNumber(n) => self.visit_float_number_expr(n),
             Expr::Name(n) => self.visit_variable_expr(n),
             Expr::ConstString(s) => self.visit_string_expr(s),
             Expr::Binary(op, a, b) => self.visit_binary_expr(op, a, b),
@@ -142,6 +143,10 @@ pub(super) trait Rewriter<E> {
 
     fn visit_number_expr(&mut self, token: Token) -> Result<Expr, E> {
         Ok(Expr::Number(token))
+    }
+
+    fn visit_float_number_expr(&mut self, token: Token) -> Result<Expr, E> {
+        Ok(Expr::FloatNumber(token))
     }
 
     fn visit_variable_expr(&mut self, variable_name: Token) -> Result<Expr, E> {

--- a/src/compile/checks/tree_visitor.rs
+++ b/src/compile/checks/tree_visitor.rs
@@ -105,6 +105,7 @@ pub(super) trait Visitor<E> {
     fn visit_expr(&mut self, expr: &Expr) -> Result<(), E> {
         match expr {
             Expr::Number(n) => self.visit_number_expr(n),
+            Expr::FloatNumber(n) => self.visit_float_number_expr(n),
             Expr::Bool(b) => self.visit_bool_expr(b),
             Expr::Name(n) => self.visit_variable_expr(n),
             Expr::ConstString(s) => self.visit_string_expr(s),
@@ -131,6 +132,10 @@ pub(super) trait Visitor<E> {
     }
 
     fn visit_number_expr(&mut self, token: &Token) -> Result<(), E> {
+        Ok(())
+    }
+
+    fn visit_float_number_expr(&mut self, token: &Token) -> Result<(), E> {
         Ok(())
     }
 

--- a/src/compile/checks/tree_visitor.rs
+++ b/src/compile/checks/tree_visitor.rs
@@ -105,6 +105,7 @@ pub(super) trait Visitor<E> {
     fn visit_expr(&mut self, expr: &Expr) -> Result<(), E> {
         match expr {
             Expr::Number(n) => self.visit_number_expr(n),
+            Expr::Bool(b) => self.visit_bool_expr(b),
             Expr::Name(n) => self.visit_variable_expr(n),
             Expr::ConstString(s) => self.visit_string_expr(s),
             Expr::Binary(op, a, b) => self.visit_binary_expr(op, a, b),
@@ -123,6 +124,10 @@ pub(super) trait Visitor<E> {
             Expr::PropertyAccess(target, prop) => self.visit_property_access(target.as_ref(), prop),
             Expr::PropertyTest(target, prop) => self.visit_property_check(target.as_ref(), prop),
         }
+    }
+
+    fn visit_bool_expr(&mut self, token: &Token) -> Result<(), E> {
+        Ok(())
     }
 
     fn visit_number_expr(&mut self, token: &Token) -> Result<(), E> {

--- a/src/compile/checks/variable_annotation_generation.rs
+++ b/src/compile/checks/variable_annotation_generation.rs
@@ -39,7 +39,6 @@ impl<'a> AnnotationGenerator<'a> {
 
         annotator.visit_expr(ast)?;
 
-        println!("ANNOTATIONS:\n{:?}", annotator.annotations);
         Ok(())
     }
 

--- a/src/compile/compiler.rs
+++ b/src/compile/compiler.rs
@@ -464,7 +464,7 @@ impl<'gc, 'annotations, 'chunk> Compiler<'gc, 'annotations, 'chunk> {
                 let mut right_side = AnnotatedCodeBlob::new();
 
                 if e.is_none() {
-                    right_side.push(Opcode::LoadImmediateInt(0), n.position.0);
+                    right_side.push(Opcode::LoadNothing, n.position.0);
                 } else {
                     self.require_value();
                     let assignment_body = self.visit_expr(e.as_ref().unwrap())?;
@@ -475,7 +475,7 @@ impl<'gc, 'annotations, 'chunk> Compiler<'gc, 'annotations, 'chunk> {
                 result.append(self.create_named_entity(n, right_side)?);
 
                 if self.needs_value() {
-                    result.push(Opcode::LoadImmediateInt(0), result.last_index().unwrap());
+                    result.push(Opcode::LoadNothing, result.last_index().unwrap());
                     //TODO dup?
                 }
             }
@@ -505,7 +505,7 @@ impl<'gc, 'annotations, 'chunk> Compiler<'gc, 'annotations, 'chunk> {
 
                 result.append(self.create_named_entity(name, right_side)?);
                 if self.needs_value() {
-                    result.push(Opcode::LoadImmediateInt(0), result.last_index().unwrap());
+                    result.push(Opcode::LoadNothing, result.last_index().unwrap());
                 }
             }
 
@@ -522,7 +522,7 @@ impl<'gc, 'annotations, 'chunk> Compiler<'gc, 'annotations, 'chunk> {
                 result.append(self.create_named_entity(name, struct_load_code)?);
 
                 if self.needs_value() {
-                    result.push(Opcode::LoadImmediateInt(0), name.position.0);
+                    result.push(Opcode::LoadNothing, name.position.0);
                 }
             }
 
@@ -630,7 +630,7 @@ impl<'gc, 'annotations, 'chunk> Compiler<'gc, 'annotations, 'chunk> {
                 }
                 //in case we need some result value
                 if self.needs_value() {
-                    result.push(Opcode::LoadImmediateInt(0), target.position.0);
+                    result.push(Opcode::LoadNothing, target.position.0);
                 }
             }
 
@@ -658,7 +658,7 @@ impl<'gc, 'annotations, 'chunk> Compiler<'gc, 'annotations, 'chunk> {
                     );
 
                     if self.needs_value() {
-                        result.push(Opcode::LoadImmediateInt(0), property.position.0);
+                        result.push(Opcode::LoadNothing, property.position.0);
                     }
                 }
 
@@ -677,7 +677,7 @@ impl<'gc, 'annotations, 'chunk> Compiler<'gc, 'annotations, 'chunk> {
                 result.append(body);
                 result.push(Opcode::Assert, token.position.0);
                 if self.needs_value() {
-                    result.push(Opcode::LoadImmediateInt(0), token.position.0);
+                    result.push(Opcode::LoadNothing, token.position.0);
                 }
             }
 
@@ -706,13 +706,13 @@ impl<'gc, 'annotations, 'chunk> Compiler<'gc, 'annotations, 'chunk> {
                 result.append(self.create_named_entity(function_name, function)?);
 
                 if self.needs_value() {
-                    result.push(Opcode::LoadImmediateInt(0), function_name.position.0);
+                    result.push(Opcode::LoadNothing, function_name.position.0);
                 }
             }
             Stmt::Pass(token) => {
                 result.push(
                     if self.needs_value() {
-                        Opcode::LoadImmediateInt(0)
+                        Opcode::LoadNothing
                     } else {
                         Opcode::Nop
                     },
@@ -865,10 +865,7 @@ impl<'gc, 'annotations, 'chunk> Compiler<'gc, 'annotations, 'chunk> {
                         let mut blob = AnnotatedCodeBlob::new();
                         if self.needs_value() {
                             {
-                                blob += (
-                                    Opcode::LoadImmediateInt(0),
-                                    *condition.indices.get(0).unwrap(),
-                                );
+                                blob += (Opcode::LoadNothing, *condition.indices.get(0).unwrap());
                             }
                         } else {
                             blob += (Opcode::Nop, *condition.indices.get(0).unwrap());
@@ -1118,7 +1115,7 @@ impl<'gc, 'annotations, 'chunk> Compiler<'gc, 'annotations, 'chunk> {
             self.declare_local(fictive_variable_name, VariableType::Normal)
                 .unwrap();
             self.define_local(fictive_variable_name);
-            result += (Opcode::LoadImmediateInt(0), block_begin.position.0); // _ variable
+            result += (Opcode::LoadNothing, block_begin.position.0); // _ variable
         }
 
         let predeclared_names = self.annotations.get_block_scope(block_begin).unwrap();

--- a/src/compile/compiler.rs
+++ b/src/compile/compiler.rs
@@ -741,6 +741,15 @@ impl<'gc, 'annotations, 'chunk> Compiler<'gc, 'annotations, 'chunk> {
                 }
             }
 
+            Expr::FloatNumber(n) => {
+                let value = n.get_float().unwrap();
+                let constant_index = self.get_or_create_constant(Value::from(value));
+                result += (Opcode::LoadConst(constant_index as u16), n.position.0);
+                if !self.needs_value() {
+                    result += (Opcode::Pop(1), n.position.0);
+                }
+            }
+
             Expr::Number(token) => {
                 let n = token.get_number().unwrap();
                 if n >= (i16::MIN as i64) && n <= (i16::MAX as i64) {

--- a/src/compile/compiler.rs
+++ b/src/compile/compiler.rs
@@ -727,6 +727,20 @@ impl<'gc, 'annotations, 'chunk> Compiler<'gc, 'annotations, 'chunk> {
     fn visit_expr(&mut self, expr: &Expr) -> Result<AnnotatedCodeBlob, String> {
         let mut result = AnnotatedCodeBlob::new();
         match expr {
+            Expr::Bool(b) => {
+                let value = match b.kind {
+                    TokenKind::True => true,
+                    TokenKind::False => false,
+                    _ => unreachable!(),
+                };
+
+                let constant_index = self.get_or_create_constant(value.into());
+                result += (Opcode::LoadConst(constant_index as u16), b.position.0);
+                if !self.needs_value() {
+                    result += (Opcode::Pop(1), b.position.0);
+                }
+            }
+
             Expr::Number(token) => {
                 let n = token.get_number().unwrap();
                 if n >= (i16::MIN as i64) && n <= (i16::MAX as i64) {

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -2,3 +2,4 @@ pub mod gc;
 pub mod marked_counter;
 pub mod objects;
 pub mod short_string;
+pub mod value_ops;

--- a/src/data/objects.rs
+++ b/src/data/objects.rs
@@ -575,6 +575,10 @@ impl StackObject {
         }
     }
 
+    pub fn as_bool(&self) -> bool {
+        !matches!(self, StackObject::Nothing | StackObject::Bool(false))
+    }
+
     pub fn get_arity(&self, context: &mut VM) -> Option<Arity> {
         match self {
             StackObject::Int(_) => None,

--- a/src/data/objects.rs
+++ b/src/data/objects.rs
@@ -508,6 +508,13 @@ impl StackObject {
         }
     }
 
+    pub fn unwrap_float(&self) -> Option<f64> {
+        match self {
+            &StackObject::Float(f) => Some(f),
+            _ => None,
+        }
+    }
+
     pub fn unwrap_partial(&self) -> Option<&mut Partial> {
         match self.as_heap_object() {
             Some(OwnedObjectItem::Partial(p)) => Some(p),

--- a/src/data/objects.rs
+++ b/src/data/objects.rs
@@ -18,11 +18,38 @@ pub const SHORT_STRING_BUF_SIZE: usize = 8;
 
 pub enum StackObject {
     Int(i64),
+    Float(f64),
+    Bool(bool),
+    Nothing,
     Blank,
     Builtin(usize),
     BuiltinMethod { class_idx: u32, method_idx: u32 },
     ShortString(ShortString<SHORT_STRING_BUF_SIZE>),
     HeapObject(PrivatePtr<OwnedObject>),
+}
+
+impl From<i64> for StackObject {
+    fn from(i: i64) -> Self {
+        Self::Int(i)
+    }
+}
+
+impl From<f64> for StackObject {
+    fn from(f: f64) -> Self {
+        Self::Float(f)
+    }
+}
+
+impl From<bool> for StackObject {
+    fn from(b: bool) -> Self {
+        Self::Bool(b)
+    }
+}
+
+impl Default for StackObject {
+    fn default() -> Self {
+        Self::Nothing
+    }
 }
 
 pub struct OwnedObject {
@@ -369,6 +396,15 @@ impl Display for StackObject {
             StackObject::Int(n) => {
                 write!(f, "{}", n)
             }
+            &StackObject::Bool(b) => {
+                write!(f, "{}", if b { "true" } else { "false" })
+            }
+            &StackObject::Float(f_) => {
+                write!(f, "{}", f_)
+            }
+            StackObject::Nothing => {
+                write!(f, "Nothing")
+            }
             StackObject::HeapObject(ptr) => {
                 write!(f, "{}", ptr.unwrap_ref())
             }
@@ -390,6 +426,9 @@ impl Debug for StackObject {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             StackObject::Int(i) => write!(f, "Int {}", i),
+            &StackObject::Bool(b) => write!(f, "Bool {}", if b { "true" } else { "false" }),
+            &StackObject::Float(v) => write!(f, "Float {}", v),
+            StackObject::Nothing => write!(f, "Nothing"),
             StackObject::HeapObject(ptr) => {
                 write!(f, "{:?}", ptr.unwrap_ref().item)
             }
@@ -417,6 +456,9 @@ impl StackObject {
         use StackObject::*;
         match self {
             Int(..) => true,
+            Bool(..) => true,
+            Float(..) => false, //sorry, no dict[0.1+0.2] for you
+            Nothing => true,
             ShortString(..) => true,
             Builtin(..) | Blank | BuiltinMethod { .. } => false,
             HeapObject(ptr) => ptr.unwrap_ref().can_hash(),
@@ -536,6 +578,7 @@ impl StackObject {
     pub fn get_arity(&self, context: &mut VM) -> Option<Arity> {
         match self {
             StackObject::Int(_) => None,
+            StackObject::Bool(..) | StackObject::Float(..) | StackObject::Nothing => None,
             StackObject::ShortString(..) => None,
             StackObject::Blank => None,
             &StackObject::Builtin(idx) => context.builtins.get_builtin_arity(idx),
@@ -615,6 +658,9 @@ impl StackObject {
     pub fn type_string(&self) -> &'static str {
         match self {
             StackObject::Int(_) => "Int",
+            StackObject::Bool(..) => "Bool",
+            StackObject::Float(..) => "Float",
+            StackObject::Nothing => "Nothing",
             StackObject::ShortString(..) => "String",
             StackObject::Builtin(_) => "Builtin",
             Self::BuiltinMethod { .. } => "BuiltinMethod",
@@ -636,11 +682,20 @@ impl StackObject {
             _ => None,
         }
     }
+
+    fn cmp_floats(obj1: &StackObject, obj2: &StackObject) -> Option<Ordering> {
+        match (obj1, obj2) {
+            (&StackObject::Float(f1), &StackObject::Float(f2)) => f1.partial_cmp(&f2),
+            _ => None,
+        }
+    }
 }
 
 impl PartialOrd for StackObject {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        StackObject::cmp_any_strings(self, other).or_else(|| StackObject::cmp_ints(self, other))
+        StackObject::cmp_any_strings(self, other)
+            .or_else(|| StackObject::cmp_ints(self, other))
+            .or_else(|| StackObject::cmp_floats(self, other))
     }
 }
 
@@ -657,6 +712,9 @@ impl PartialEq for StackObject {
 
         match (self, other) {
             (StackObject::Int(a), StackObject::Int(b)) => a == b,
+            (StackObject::Float(f1), StackObject::Float(f2)) => f1 == f2,
+            (StackObject::Bool(b1), StackObject::Bool(b2)) => b1 == b2,
+            (StackObject::Nothing, StackObject::Nothing) => true,
             (StackObject::HeapObject(ptr1), StackObject::HeapObject(ptr2)) => {
                 std::ptr::eq(ptr1.unwrap(), ptr2.unwrap()) || ptr1.unwrap_ref() == ptr2.unwrap_ref()
             }
@@ -675,6 +733,8 @@ impl Hash for StackObject {
     fn hash<H: Hasher>(&self, state: &mut H) {
         match self {
             StackObject::Int(i) => i.hash(state),
+            StackObject::Bool(b) => b.hash(state),
+            StackObject::Nothing => 0usize.hash(state),
             StackObject::ShortString(s) => s.as_str().hash(state),
             StackObject::HeapObject(ptr) => ptr.unwrap_ref().hash(state),
             other => panic!("cannot hash {:?}", other),

--- a/src/data/value_ops.rs
+++ b/src/data/value_ops.rs
@@ -1,0 +1,185 @@
+use crate::data::objects::Value;
+
+#[derive(Copy, Clone, Debug)]
+pub enum NumberCastResult {
+    Int(i64),
+    Float(f64),
+}
+
+impl NumberCastResult {
+    pub fn downgrade(&self) -> f64 {
+        match *self {
+            Self::Float(f) => f,
+            Self::Int(n) => n as f64,
+        }
+    }
+}
+
+pub fn numeric_cast(value: &Value) -> Option<NumberCastResult> {
+    value
+        .unwrap_int()
+        .map(NumberCastResult::Int)
+        .or_else(|| value.unwrap_float().map(NumberCastResult::Float))
+}
+
+pub fn equality_operator(left: &Value, right: &Value) -> bool {
+    left.eq(right) || {
+        let left = numeric_cast(left);
+        let right = numeric_cast(right);
+        left.and(right)
+            .map(|_| left.unwrap().downgrade() == right.unwrap().downgrade())
+            .unwrap_or(false)
+    }
+}
+
+macro_rules! cast_binary {
+    ($left:expr, $op:tt, $right:expr ) => {
+        match ($left, $right) {
+            (&Value::Int(left), &Value::Int(right)) => Some((left $op right).into()),
+            (left, right) => {
+                use crate::data::value_ops::numeric_cast;
+                fn f(left: &Value, right: &Value) -> Option<Value> {
+                    let left = numeric_cast(left)?;
+                    let right = numeric_cast(right)?;
+                    Some((left.downgrade() $op right.downgrade()).into())
+                }
+                f(left, right)
+            }
+        }
+    };
+}
+
+macro_rules! comparison_operator {
+    ($left:expr, $right:expr, $pat:pat) => {
+        match $left.partial_cmp($right).or_else(|| {
+            use crate::data::value_ops::numeric_cast;
+            let left = numeric_cast($left)?;
+            let right = numeric_cast($right)?;
+            left.downgrade().partial_cmp(&right.downgrade())
+        }) {
+            Some($pat) => Some(true),
+            Some(_) => Some(false),
+
+            None => None,
+        }
+    };
+}
+
+pub(crate) use cast_binary;
+pub(crate) use comparison_operator;
+
+#[cfg(test)]
+mod tests {
+    use std::cmp::Ordering;
+
+    use crate::data::gc::GC;
+    use rstest::*;
+
+    use super::*;
+
+    #[fixture]
+    pub fn gc() -> GC {
+        unsafe { GC::default_gc() }
+    }
+
+    #[rstest]
+    fn cmp_should_work_for_strings(mut gc: GC) {
+        let s123 = gc.store("123".to_string());
+        let s123_2 = gc.store("123".to_string());
+        let s124 = gc.store("124".to_string());
+
+        assert_eq!(
+            comparison_operator!(&s123, &s123_2, Ordering::Equal),
+            Some(true)
+        );
+        assert_eq!(
+            comparison_operator!(&s123, &s123_2, Ordering::Equal | Ordering::Greater),
+            Some(true)
+        );
+
+        assert_eq!(
+            comparison_operator!(&s123, &s124, Ordering::Equal),
+            Some(false)
+        );
+
+        assert_eq!(
+            comparison_operator!(&s123, &s124, Ordering::Less),
+            Some(true)
+        );
+        drop(s123);
+        drop(s123_2);
+        drop(s124);
+    }
+
+    #[rstest]
+    fn eq_should_work_for_strings(mut gc: GC) {
+        let s123 = gc.store("123".to_string());
+        let s123_2 = gc.store("123".to_string());
+        let s124 = gc.store("124".to_string());
+
+        assert!(equality_operator(&s123, &s123_2));
+        assert!(!equality_operator(&s123, &s124));
+
+        drop(s123);
+        drop(s123_2);
+        drop(s124);
+    }
+
+    #[test]
+    fn cmp_should_work_for_ints() {
+        assert_eq!(
+            comparison_operator!(&Value::Int(0), &Value::Int(0), Ordering::Equal),
+            Some(true)
+        );
+        assert_eq!(
+            comparison_operator!(
+                &Value::Int(0),
+                &Value::Int(0),
+                Ordering::Greater | Ordering::Equal
+            ),
+            Some(true)
+        );
+
+        assert_eq!(
+            comparison_operator!(&Value::Int(0), &Value::Int(1), Ordering::Equal),
+            Some(false)
+        );
+
+        assert_eq!(
+            comparison_operator!(&Value::Int(0), &Value::Int(1), Ordering::Less),
+            Some(true)
+        );
+    }
+
+    #[test]
+    fn eq_should_work_for_ints() {
+        assert!(equality_operator(&12i64.into(), &12i64.into()));
+        assert!(!equality_operator(&12i64.into(), &13i64.into()));
+    }
+
+    #[rstest]
+    fn eq_should_work_for_incompatible(mut gc: GC) {
+        let s = gc.store("12".to_string());
+
+        assert!(!equality_operator(&s, &12.into()));
+        drop(s)
+    }
+
+    #[test]
+    fn eq_should_work_for_mixed_numbers() {
+        assert!(equality_operator(&12i64.into(), &12f64.into()));
+        assert!(!equality_operator(&12i64.into(), &10f64.into()));
+    }
+
+    #[test]
+    fn cmp_should_work_for_mixed_numbers() {
+        assert_eq!(
+            comparison_operator!(&Value::from(12i64), &13f64.into(), Ordering::Less),
+            Some(true),
+        );
+        assert_eq!(
+            comparison_operator!(&Value::from(12i64), &13f64.into(), Ordering::Greater),
+            Some(false)
+        );
+    }
+}

--- a/src/execution/builtins.rs
+++ b/src/execution/builtins.rs
@@ -198,8 +198,6 @@ pub fn builtin_factory() -> BuiltinMap {
         }
     }
 
-    value!("true", true.into());
-    value!("false", false.into());
     value!("Nothing", Default::default());
 
     builtin!("sum", AtLeast(0), |args, _vm| {

--- a/src/execution/builtins.rs
+++ b/src/execution/builtins.rs
@@ -257,7 +257,7 @@ pub fn builtin_factory() -> BuiltinMap {
     #[cfg(test)]
     builtin!("set_stack_limit", Exact(1), |args, vm| {
         vm.override_stack_limit(args[0].unwrap_int().unwrap() as usize);
-        Ok(Value::Int(0))
+        Ok(Default::default())
     });
 
     builtin!("is_vararg", Exact(1), |args, vm| {
@@ -268,7 +268,7 @@ pub fn builtin_factory() -> BuiltinMap {
             .unwrap_or(Arity::Exact(0))
             .is_vararg();
 
-        Ok(Value::Int(if v { 1 } else { 0 }))
+        Ok(v.into())
     });
 
     builtin!("print", AtLeast(0), |args, vm| {
@@ -282,7 +282,7 @@ pub fn builtin_factory() -> BuiltinMap {
 
         println!("{}", s);
 
-        Ok(Value::Int(0))
+        Ok(Default::default())
     });
 
     methods!("Int",

--- a/src/execution/chunk.rs
+++ b/src/execution/chunk.rs
@@ -37,6 +37,7 @@ pub enum Opcode {
     LoadClosureValue(u16),
 
     LoadBlank,
+    LoadNothing,
     CallPartial(u16),
 
     Duplicate,

--- a/src/execution/vm.rs
+++ b/src/execution/vm.rs
@@ -1,5 +1,6 @@
 use crate::data::gc::GC;
 use crate::data::objects::{Closure, StackObject, VVec, Value, ValueBox};
+use crate::data::value_ops::{self, cast_binary, numeric_cast, NumberCastResult};
 use crate::execution::chunk::Opcode;
 use std::cmp::Ordering;
 use std::collections::HashMap;
@@ -249,12 +250,15 @@ impl<'gc, 'builtins> VM<'gc, 'builtins> {
             ($pat:pat) => {{
                 let second_operand = checked_stack_pop!()?;
                 let first_operand = checked_stack_pop!()?;
-                let value = match first_operand.partial_cmp(&second_operand) {
-                    $pat => Ok(true.into()),
-                    Some(_) => Ok(false.into()),
+                let value = match crate::data::value_ops::comparison_operator!(
+                    &first_operand,
+                    &second_operand,
+                    $pat
+                ) {
+                    Some(v) => Ok(v.into()),
                     None => Err(runtime_error!(InterpretErrorKind::TypeError {
                         message: format!(
-                            "got unsupported argument types ({} and {})",
+                            "got unsupported values in comparison ({} and {})",
                             first_operand.type_string(),
                             second_operand.type_string()
                         )
@@ -310,56 +314,89 @@ impl<'gc, 'builtins> VM<'gc, 'builtins> {
                 let second_operand = checked_stack_pop!()?;
                 let first_operand = checked_stack_pop!()?;
 
-                match (&first_operand, &second_operand) {
+                let value = match (&first_operand, &second_operand) {
                     (s1, s2) if s1.unwrap_any_str().is_some() && s2.unwrap_any_str().is_some() => {
-                        let resulting_string = self
-                            .gc
+                        self.gc
                             .try_inplace_string_concat(first_operand, second_operand)
-                            .map_err(|o| {
-                                runtime_error!(InterpretErrorKind::TypeError { message: o })
-                            })?;
-                        self.stack.push(resulting_string);
+                            .unwrap()
                     }
 
-                    (StackObject::Int(n1), StackObject::Int(n2)) => {
-                        self.stack.push(Value::Int(*n1 + *n2));
+                    (_, _) => {
+                        cast_binary!(&first_operand, +, &second_operand).ok_or_else(|| {
+                            runtime_error!(InterpretErrorKind::TypeError {
+                                message: format!(
+                                    "uncompatible types in Add (got {} and {})",
+                                    first_operand.type_string(),
+                                    second_operand.type_string()
+                                )
+                            })
+                        })?
                     }
-                    (other_1, other_2) => {
-                        return Err(runtime_error!(InterpretErrorKind::TypeError {
-                            message: format!(
-                                "uncompatible types in Add (got {} and {})",
-                                other_1.type_string(),
-                                other_2.type_string()
-                            )
-                        }));
-                    }
-                }
+                };
+                self.stack.push(value);
 
                 InstructionExecution::NextInstruction
             }
 
             Opcode::Sub => {
-                let second_operand = as_int!(checked_stack_pop!()?)?;
-                let first_operand = as_int!(checked_stack_pop!()?)?;
-                self.stack.push(Value::Int(first_operand - second_operand));
+                let second_operand = checked_stack_pop!()?;
+                let first_operand = checked_stack_pop!()?;
+                self.stack
+                    .push(
+                        cast_binary!(&first_operand, -, &second_operand).ok_or_else(|| {
+                            runtime_error!(InterpretErrorKind::TypeError {
+                                message: format!(
+                                    "uncompatible types in Sub (got {} and {})",
+                                    first_operand.type_string(),
+                                    second_operand.type_string()
+                                )
+                            })
+                        })?,
+                    );
                 InstructionExecution::NextInstruction
             }
 
             Opcode::Mul => {
-                let second_operand = as_int!(checked_stack_pop!()?)?;
-                let first_operand = as_int!(checked_stack_pop!()?)?;
-                self.stack.push(Value::Int(first_operand * second_operand));
+                let second_operand = checked_stack_pop!()?;
+                let first_operand = checked_stack_pop!()?;
+                self.stack
+                    .push(
+                        cast_binary!(&first_operand, *, &second_operand).ok_or_else(|| {
+                            runtime_error!(InterpretErrorKind::TypeError {
+                                message: format!(
+                                    "uncompatible types in Multiply (got {} and {})",
+                                    first_operand.type_string(),
+                                    second_operand.type_string()
+                                )
+                            })
+                        })?,
+                    );
                 InstructionExecution::NextInstruction
             }
 
             Opcode::Div => {
-                let second_operand = as_int!(checked_stack_pop!()?)?;
-                let first_operand = as_int!(checked_stack_pop!()?)?;
+                let second_operand = checked_stack_pop!()?;
+                let first_operand = checked_stack_pop!()?;
 
-                let value = first_operand
-                    .checked_div(second_operand)
-                    .ok_or(runtime_error!(ZeroDivision))?;
-                self.stack.push(Value::Int(value));
+                if second_operand.unwrap_int().map(|i| i == 0i64) == Some(true)
+                    || second_operand.unwrap_float().map(|f| f.abs() == 0f64) == Some(true)
+                {
+                    return Err(runtime_error!(ZeroDivision));
+                }
+
+                self.stack
+                    .push(
+                        cast_binary!(&first_operand, /, &second_operand).ok_or_else(|| {
+                            runtime_error!(InterpretErrorKind::TypeError {
+                                message: format!(
+                                    "uncompatible types in Divide (got {} and {})",
+                                    first_operand.type_string(),
+                                    second_operand.type_string()
+                                )
+                            })
+                        })?,
+                    );
+
                 InstructionExecution::NextInstruction
             }
 
@@ -375,10 +412,35 @@ impl<'gc, 'builtins> VM<'gc, 'builtins> {
             }
 
             Opcode::Power => {
-                let second_operand = as_int!(checked_stack_pop!()?)?;
-                let first_operand = as_int!(checked_stack_pop!()?)?;
-                let value = first_operand.pow(second_operand as u64 as u32);
-                self.stack.push(Value::Int(value));
+                let second_operand = checked_stack_pop!()?;
+                let first_operand = checked_stack_pop!()?;
+
+                let value: Value =
+                    match (numeric_cast(&first_operand), numeric_cast(&second_operand)) {
+                        (Some(NumberCastResult::Int(a)), Some(NumberCastResult::Int(b))) => {
+                            if b < 0 || b > u32::MAX as i64 {
+                                return Err(runtime_error!(InterpretErrorKind::NativeError {
+                                    message: format!("unsupported operand {} in pow", b)
+                                }));
+                            }
+                            a.pow(b as u64 as u32).into()
+                        }
+
+                        (Some(first), Some(second)) => {
+                            (first.downgrade().powf(second.downgrade())).into()
+                        }
+                        _ => {
+                            return Err(runtime_error!(InterpretErrorKind::TypeError {
+                                message: format!(
+                                    "expected numbers in pow, got {} and {}",
+                                    first_operand.type_string(),
+                                    second_operand.type_string()
+                                )
+                            }));
+                        }
+                    };
+
+                self.stack.push(value);
                 InstructionExecution::NextInstruction
             }
 
@@ -504,29 +566,31 @@ impl<'gc, 'builtins> VM<'gc, 'builtins> {
             Opcode::TestEquals => {
                 let second_operand = checked_stack_pop!()?;
                 let first_operand = checked_stack_pop!()?;
-                self.stack.push((second_operand == first_operand).into());
+                self.stack
+                    .push(value_ops::equality_operator(&first_operand, &second_operand).into());
                 InstructionExecution::NextInstruction
             }
 
             Opcode::TestNotEquals => {
                 let second_operand = checked_stack_pop!()?;
                 let first_operand = checked_stack_pop!()?;
-                self.stack.push((second_operand != first_operand).into());
+                self.stack
+                    .push((!value_ops::equality_operator(&first_operand, &second_operand)).into());
                 InstructionExecution::NextInstruction
             }
 
             Opcode::TestGreater => {
-                comparison_operator!(Some(Ordering::Greater))
+                comparison_operator!(Ordering::Greater)
             }
 
             Opcode::TestGreaterEqual => {
-                comparison_operator!(Some(Ordering::Equal | Ordering::Greater))
+                comparison_operator!(Ordering::Equal | Ordering::Greater)
             }
 
-            Opcode::TestLess => comparison_operator!(Some(Ordering::Less)),
+            Opcode::TestLess => comparison_operator!(Ordering::Less),
 
             Opcode::TestLessEqual => {
-                comparison_operator!(Some(Ordering::Equal | Ordering::Less))
+                comparison_operator!(Ordering::Equal | Ordering::Less)
             }
 
             Opcode::TestProperty(idx) => {

--- a/src/execution/vm.rs
+++ b/src/execution/vm.rs
@@ -956,6 +956,11 @@ impl<'gc, 'builtins> VM<'gc, 'builtins> {
                 InstructionExecution::NextInstruction
             }
 
+            Opcode::LoadNothing => {
+                self.stack.push(StackObject::Nothing);
+                InstructionExecution::NextInstruction
+            }
+
             Opcode::MakeList(size) => {
                 let size = size as usize;
                 self.check_underflow(size + 1)

--- a/src/parsing/ast.rs
+++ b/src/parsing/ast.rs
@@ -39,6 +39,7 @@ pub enum Stmt {
 #[derive(Clone, Debug)]
 pub enum Expr {
     Number(Token),
+    FloatNumber(Token),
     Bool(Token),
     Name(Token),
     ConstString(Token),

--- a/src/parsing/ast.rs
+++ b/src/parsing/ast.rs
@@ -39,6 +39,7 @@ pub enum Stmt {
 #[derive(Clone, Debug)]
 pub enum Expr {
     Number(Token),
+    Bool(Token),
     Name(Token),
     ConstString(Token),
     Binary(Token, Box<Expr>, Box<Expr>),

--- a/src/parsing/lexer.rs
+++ b/src/parsing/lexer.rs
@@ -61,6 +61,9 @@ pub enum TokenKind {
     Name(String),
     ConstString(String),
 
+    True,
+    False,
+
     Assert,
     Var,
     If,
@@ -156,6 +159,8 @@ impl<'input> Lexer<'input> {
             ("struct", Struct),
             ("enum", Enum),
             ("impl", Impl),
+            ("true", True),
+            ("false", False),
         ]
         .into_iter()
         .map(|(k, v)| (k.to_string(), v))

--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -323,6 +323,7 @@ peg::parser! {
 
         rule term() -> Expr
             = [num@t!(Number(..))] {Expr::Number(num)}
+            / [num @ t!(FloatNumber(..))] {Expr::FloatNumber(num)}
             / [b@t!(True) | b@t!(False)] {Expr::Bool(b)}
             / t:name()
                 {Expr::Name(t)}

--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -323,6 +323,7 @@ peg::parser! {
 
         rule term() -> Expr
             = [num@t!(Number(..))] {Expr::Number(num)}
+            / [b@t!(True) | b@t!(False)] {Expr::Bool(b)}
             / t:name()
                 {Expr::Name(t)}
             / [s@t!(ConstString(..))] {Expr::ConstString(s)}


### PR DESCRIPTION
Add basic types common to other languages like float-point numbers and booleans. Booleans should replace 0 and 1 integers in control flow instructions